### PR TITLE
Release docker image for Linux/ARM64

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -1,0 +1,28 @@
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login do docker.io
+        run: docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+      - name: build and publish image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ secrets.DOCKER_USERNAME }}/mailhog:latest


### PR DESCRIPTION
Hi

Package Owner: Vigneshwar A J 

PR change Details:

Patch Details: Following files has been created :

.github/workflows/build_push.yml : Added buildx support through this file to push docker image for arm64 and amd64 platforms using GitHub actions.

PR Description:
Commit message: Add buildx support to release ARM64 images

The following file has been created :

.github/workflows/build_push.yml : Added buildx support through this file to push docker image for arm64 and amd64 platforms using GitHub actions.

Signed-off-by: odidev odidev@puresoftware.com

Peer Reviewer : Sakshi Sharma 

Reviewer: Pruthvi Teja Reddy

Thanks
Vigneshwar A J

